### PR TITLE
fix: keep streamed usage token counts accurate

### DIFF
--- a/internal/runtime/executor/usage_helpers.go
+++ b/internal/runtime/executor/usage_helpers.go
@@ -243,19 +243,40 @@ func parseOpenAIStreamUsage(line []byte) (usage.Detail, bool) {
 		return usage.Detail{}, false
 	}
 	usageNode := gjson.GetBytes(payload, "usage")
-	if !usageNode.Exists() {
+	if !usageNode.Exists() || usageNode.Type == gjson.Null {
 		return usage.Detail{}, false
 	}
+
+	inputNode := usageNode.Get("prompt_tokens")
+	if !inputNode.Exists() {
+		inputNode = usageNode.Get("input_tokens")
+	}
+	outputNode := usageNode.Get("completion_tokens")
+	if !outputNode.Exists() {
+		outputNode = usageNode.Get("output_tokens")
+	}
+	cachedNode := usageNode.Get("prompt_tokens_details.cached_tokens")
+	if !cachedNode.Exists() {
+		cachedNode = usageNode.Get("input_tokens_details.cached_tokens")
+	}
+	reasoningNode := usageNode.Get("completion_tokens_details.reasoning_tokens")
+	if !reasoningNode.Exists() {
+		reasoningNode = usageNode.Get("output_tokens_details.reasoning_tokens")
+	}
+	totalNode := usageNode.Get("total_tokens")
+	if !inputNode.Exists() && !outputNode.Exists() && !cachedNode.Exists() && !reasoningNode.Exists() && !totalNode.Exists() {
+		return usage.Detail{}, false
+	}
+
 	detail := usage.Detail{
-		InputTokens:  usageNode.Get("prompt_tokens").Int(),
-		OutputTokens: usageNode.Get("completion_tokens").Int(),
-		TotalTokens:  usageNode.Get("total_tokens").Int(),
+		InputTokens:     inputNode.Int(),
+		OutputTokens:    outputNode.Int(),
+		ReasoningTokens: reasoningNode.Int(),
+		CachedTokens:    cachedNode.Int(),
+		TotalTokens:     totalNode.Int(),
 	}
-	if cached := usageNode.Get("prompt_tokens_details.cached_tokens"); cached.Exists() {
-		detail.CachedTokens = cached.Int()
-	}
-	if reasoning := usageNode.Get("completion_tokens_details.reasoning_tokens"); reasoning.Exists() {
-		detail.ReasoningTokens = reasoning.Int()
+	if detail.TotalTokens == 0 {
+		detail.TotalTokens = detail.InputTokens + detail.OutputTokens + detail.ReasoningTokens
 	}
 	return detail, true
 }

--- a/internal/runtime/executor/usage_helpers_test.go
+++ b/internal/runtime/executor/usage_helpers_test.go
@@ -50,6 +50,90 @@ func TestParseOpenAIUsageResponses(t *testing.T) {
 	}
 }
 
+func TestParseOpenAIStreamUsageIgnoresNullUsage(t *testing.T) {
+	line := []byte(`data: {"id":"chatcmpl-null","choices":[{"delta":{"content":"ok"},"index":0}],"usage":null}`)
+	if detail, ok := parseOpenAIStreamUsage(line); ok {
+		t.Fatalf("expected null usage to be ignored, got ok=%t detail=%+v", ok, detail)
+	}
+}
+
+func TestParseOpenAIStreamUsageSupportsResponsesFields(t *testing.T) {
+	line := []byte(`data: {"usage":{"input_tokens":320,"output_tokens":1,"input_tokens_details":{"cached_tokens":2},"output_tokens_details":{"reasoning_tokens":5}}}`)
+	detail, ok := parseOpenAIStreamUsage(line)
+	if !ok {
+		t.Fatal("expected responses-style stream usage to be parsed")
+	}
+	if detail.InputTokens != 320 {
+		t.Fatalf("input tokens = %d, want %d", detail.InputTokens, 320)
+	}
+	if detail.OutputTokens != 1 {
+		t.Fatalf("output tokens = %d, want %d", detail.OutputTokens, 1)
+	}
+	if detail.CachedTokens != 2 {
+		t.Fatalf("cached tokens = %d, want %d", detail.CachedTokens, 2)
+	}
+	if detail.ReasoningTokens != 5 {
+		t.Fatalf("reasoning tokens = %d, want %d", detail.ReasoningTokens, 5)
+	}
+}
+
+func TestUsageReporterStreamIgnoresNullUsageUntilFinalUsage(t *testing.T) {
+	wasEnabled := internalusage.StatisticsEnabled()
+	internalusage.SetStatisticsEnabled(true)
+	defer internalusage.SetStatisticsEnabled(wasEnabled)
+
+	apiKey := fmt.Sprintf("stream-null-usage-api-%d", time.Now().UnixNano())
+	model := fmt.Sprintf("stream-null-usage-model-%d", time.Now().UnixNano())
+	reporter := &usageReporter{
+		provider:    "qwen",
+		model:       model,
+		apiKey:      apiKey,
+		requestedAt: time.Now(),
+	}
+
+	lines := [][]byte{
+		[]byte(`data: {"id":"chatcmpl-null","choices":[{"delta":{"content":"o"},"index":0}],"usage":null}`),
+		[]byte(`data: {"id":"chatcmpl-final","choices":[{"delta":{},"index":0,"finish_reason":"stop"}],"usage":{"prompt_tokens":13,"completion_tokens":1,"total_tokens":14}}`),
+	}
+
+	for _, line := range lines {
+		if detail, ok := parseOpenAIStreamUsage(line); ok {
+			reporter.publish(context.Background(), detail)
+		}
+	}
+
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		snapshot := internalusage.GetRequestStatistics().Snapshot()
+		apiStats, ok := snapshot.APIs[apiKey]
+		if !ok {
+			time.Sleep(10 * time.Millisecond)
+			continue
+		}
+		modelStats, ok := apiStats.Models[model]
+		if !ok {
+			time.Sleep(10 * time.Millisecond)
+			continue
+		}
+		if modelStats.TotalRequests != 1 {
+			time.Sleep(10 * time.Millisecond)
+			continue
+		}
+		if modelStats.TotalTokens != 14 {
+			t.Fatalf("total tokens = %d, want 14", modelStats.TotalTokens)
+		}
+		if len(modelStats.Details) != 1 {
+			t.Fatalf("details len = %d, want 1", len(modelStats.Details))
+		}
+		if modelStats.Details[0].Tokens.TotalTokens != 14 {
+			t.Fatalf("detail total tokens = %d, want 14", modelStats.Details[0].Tokens.TotalTokens)
+		}
+		return
+	}
+
+	t.Fatal("expected final stream usage to be recorded")
+}
+
 func TestUsageReporterBuildRecordIncludesLatency(t *testing.T) {
 	reporter := &usageReporter{
 		provider:    "openai",


### PR DESCRIPTION
## Summary
- ignore streamed `usage: null` / empty usage chunks so they do not preempt the final token record
- support `input_tokens` / `output_tokens` stream usage fields in addition to `prompt_tokens` / `completion_tokens`
- add regression coverage for null streamed usage, responses-style stream usage, and reporter behavior across null -> final usage

## Reproduction
Before this change, Qwen requests routed through `POST /v1/messages` with `stream=true` could show request counts but `0` token totals, because an early empty usage chunk won the `once.Do` race before the final usage chunk arrived.

## Validation
- `go test ./internal/runtime/executor -run 'Test(ParseOpenAIStreamUsageIgnoresNullUsage|ParseOpenAIStreamUsageSupportsResponsesFields|UsageReporterStreamIgnoresNullUsageUntilFinalUsage)' -count=1`
- `go test ./internal/runtime/executor ./internal/usage ./internal/api/handlers/management ./internal/api -count=1`
- local end-to-end replay against restarted server: streamed `POST /v1/messages` for Qwen now persists non-zero token totals in `/tmp/cliproxyapi-dev/usage-statistics.json`
