### PR TITLE
fix: ignore placeholder stream usage chunks

### DIFF
--- a/internal/runtime/executor/kimi_executor.go
+++ b/internal/runtime/executor/kimi_executor.go
@@ -282,7 +282,9 @@ func (e *KimiExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.Aut
 			recordAPIResponseError(ctx, e.cfg, errScan)
 			reporter.publishFailure(ctx)
 			out <- cliproxyexecutor.StreamChunk{Err: errScan}
+			return
 		}
+		reporter.ensurePublished(ctx)
 	}()
 	return &cliproxyexecutor.StreamResult{Headers: httpResp.Header.Clone(), Chunks: out}, nil
 }

--- a/internal/runtime/executor/qwen_executor.go
+++ b/internal/runtime/executor/qwen_executor.go
@@ -432,7 +432,9 @@ func (e *QwenExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.Aut
 			recordAPIResponseError(ctx, e.cfg, errScan)
 			reporter.publishFailure(ctx)
 			out <- cliproxyexecutor.StreamChunk{Err: errScan}
+			return
 		}
+		reporter.ensurePublished(ctx)
 	}()
 	return &cliproxyexecutor.StreamResult{Headers: httpResp.Header.Clone(), Chunks: out}, nil
 }

--- a/internal/runtime/executor/usage_helpers.go
+++ b/internal/runtime/executor/usage_helpers.go
@@ -278,6 +278,9 @@ func parseOpenAIStreamUsage(line []byte) (usage.Detail, bool) {
 	if detail.TotalTokens == 0 {
 		detail.TotalTokens = detail.InputTokens + detail.OutputTokens + detail.ReasoningTokens
 	}
+	if detail.TotalTokens == 0 && detail.InputTokens == 0 && detail.OutputTokens == 0 && detail.ReasoningTokens == 0 && detail.CachedTokens == 0 {
+		return usage.Detail{}, false
+	}
 	return detail, true
 }
 

--- a/internal/runtime/executor/usage_helpers_test.go
+++ b/internal/runtime/executor/usage_helpers_test.go
@@ -57,6 +57,69 @@ func TestParseOpenAIStreamUsageIgnoresNullUsage(t *testing.T) {
 	}
 }
 
+func TestParseOpenAIStreamUsageIgnoresZeroPlaceholderUsage(t *testing.T) {
+	line := []byte(`data: {"usage":{"prompt_tokens":0,"completion_tokens":0,"total_tokens":0}}`)
+	if detail, ok := parseOpenAIStreamUsage(line); ok {
+		t.Fatalf("expected zero placeholder usage to be ignored, got ok=%t detail=%+v", ok, detail)
+	}
+}
+
+func TestUsageReporterStreamIgnoresZeroPlaceholderUntilFinalUsage(t *testing.T) {
+	wasEnabled := internalusage.StatisticsEnabled()
+	internalusage.SetStatisticsEnabled(true)
+	defer internalusage.SetStatisticsEnabled(wasEnabled)
+
+	apiKey := fmt.Sprintf("stream-zero-usage-api-%d", time.Now().UnixNano())
+	model := fmt.Sprintf("stream-zero-usage-model-%d", time.Now().UnixNano())
+	reporter := &usageReporter{
+		provider:    "qwen",
+		model:       model,
+		apiKey:      apiKey,
+		requestedAt: time.Now(),
+	}
+
+	lines := [][]byte{
+		[]byte(`data: {"id":"chatcmpl-zero","choices":[{"delta":{"content":"o"},"index":0}],"usage":{"prompt_tokens":0,"completion_tokens":0,"total_tokens":0}}`),
+		[]byte(`data: {"id":"chatcmpl-final","choices":[{"delta":{},"index":0,"finish_reason":"stop"}],"usage":{"input_tokens":320,"output_tokens":1}}`),
+	}
+
+	for _, line := range lines {
+		if detail, ok := parseOpenAIStreamUsage(line); ok {
+			reporter.publish(context.Background(), detail)
+		}
+	}
+
+	reporter.ensurePublished(context.Background())
+
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		snapshot := internalusage.GetRequestStatistics().Snapshot()
+		apiStats, ok := snapshot.APIs[apiKey]
+		if !ok {
+			time.Sleep(10 * time.Millisecond)
+			continue
+		}
+		modelStats, ok := apiStats.Models[model]
+		if !ok {
+			time.Sleep(10 * time.Millisecond)
+			continue
+		}
+		if modelStats.TotalRequests != 1 {
+			time.Sleep(10 * time.Millisecond)
+			continue
+		}
+		if modelStats.TotalTokens != 321 {
+			t.Fatalf("total tokens = %d, want 321", modelStats.TotalTokens)
+		}
+		if modelStats.Details[0].Tokens.TotalTokens != 321 {
+			t.Fatalf("detail total tokens = %d, want 321", modelStats.Details[0].Tokens.TotalTokens)
+		}
+		return
+	}
+
+	t.Fatal("expected final stream usage to override placeholder usage")
+}
+
 func TestParseOpenAIStreamUsageSupportsResponsesFields(t *testing.T) {
 	line := []byte(`data: {"usage":{"input_tokens":320,"output_tokens":1,"input_tokens_details":{"cached_tokens":2},"output_tokens_details":{"reasoning_tokens":5}}}`)
 	detail, ok := parseOpenAIStreamUsage(line)


### PR DESCRIPTION
## Summary
- ignore streamed placeholder usage chunks where all token counters are zero
- call `ensurePublished` at the end of Qwen/Kimi OpenAI-style streaming executors so request counts still persist when upstream never sends a final usage block
- extend regression coverage for zero-placeholder usage before the final streamed usage block

## Why
PR #16 fixed `usage: null` and responses-style streamed fields, but live replay showed one more provider behavior: some streamed chunks contain a non-null `usage` object with all-zero counters before the final real usage arrives. That still won the reporter `once.Do` race and caused zero-token statistics.

## Validation
- `go test ./internal/runtime/executor -run 'Test(ParseOpenAIStreamUsageIgnoresNullUsage|ParseOpenAIStreamUsageIgnoresZeroPlaceholderUsage|ParseOpenAIStreamUsageSupportsResponsesFields|UsageReporterStreamIgnoresNullUsageUntilFinalUsage|UsageReporterStreamIgnoresZeroPlaceholderUntilFinalUsage)' -count=1`
- `go test ./internal/runtime/executor ./internal/usage ./internal/api/handlers/management ./internal/api -count=1`
- local replay against restarted server: streamed `POST /v1/messages` for Qwen now persists `321` tokens instead of `0`
